### PR TITLE
Remove root

### DIFF
--- a/software/gui/CMakeLists.txt
+++ b/software/gui/CMakeLists.txt
@@ -5,18 +5,9 @@ if(NOT JADE_BUILD_GUI)
 endif()
 
 find_package(Qt5 COMPONENTS Widgets PrintSupport REQUIRED)
-find_package(ROOT REQUIRED)
 
 include_directories(include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-include_directories(${ROOT_INCLUDE_DIRS})
-set(USEROOT true)
-if(USEROOT)
-  execute_process(COMMAND root-config --cflags OUTPUT_VARIABLE ROOT_CXX_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process(COMMAND root-config --libs OUTPUT_VARIABLE ROOT_LD_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE) 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ROOT_CXX_FLAGS}")
-  set(CMAKE_EXE_LINKER_FLAGS "${ROOT_LD_FLAGS}")
-endif(USEROOT)
 
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/src GUI_SRC)
 
@@ -38,7 +29,6 @@ add_executable(${JADE_GUI} ${GUI_APP} ${GUI_SRC} ${GUI_HEADERS_MOC} ${GUI_FORMS_
 qt5_use_modules(${JADE_GUI} Widgets PrintSupport)
 
 target_link_libraries(${JADE_GUI} ${JADE_CORE_LIBRARY})
-target_link_libraries(${JADE_GUI} ${ROOT_LIBRARIES})
 
 install(TARGETS ${JADE_GUI}
     DESTINATION bin)

--- a/software/gui/include/GUIMonitor.hh
+++ b/software/gui/include/GUIMonitor.hh
@@ -4,11 +4,12 @@
 #include "JadeMonitor.hh"
 #include "JadeOption.hh"
 #include "qcustomplot.h"
-#include "TH1D.h"
 #include <algorithm>    
 #include <vector>       
 #include <functional>
 #include <mutex>
+#include <unordered_map>
+
 
 class GUIMonitor : public JadeMonitor
 {
@@ -19,6 +20,7 @@ class GUIMonitor : public JadeMonitor
     QVector<QCPGraphData> GetPedestal(int col, int row);
     QVector<QCPGraphData> GetNoise(int col, int row);
     void Reset();
+    std::unordered_map<double, size_t> GetHistogram(const std::vector<double>& xVec);
 
   private:
     JadeOption m_opt;
@@ -43,12 +45,15 @@ class GUIMonitor : public JadeMonitor
     std::vector<int16_t> m_sum_frame_adc;
     std::vector<double> m_mean_frame_adc;
     std::vector<double> m_rms_frame_adc;
+    std::vector<double> m_mean;
+    std::vector<double> m_rms;
+
     struct adcFrame {
       std::vector<int16_t> cds_frame_adc;
       std::vector<double> mean_frame_adc;
       std::vector<double> rms_frame_adc;
-      std::shared_ptr<TH1D> hist_mean;
-      std::shared_ptr<TH1D> hist_rms;
+      std::unordered_map<double, size_t> hist_mean;
+      std::unordered_map<double, size_t> hist_rms;
     };
     std::shared_ptr<adcFrame> m_adcFrame; 
     std::shared_ptr<adcFrame> m_u_adcFrame; 

--- a/software/gui/include/GUIMonitor.hh
+++ b/software/gui/include/GUIMonitor.hh
@@ -8,8 +8,8 @@
 #include <vector>       
 #include <functional>
 #include <mutex>
-#include <unordered_map>
-
+#include <map>
+#include <iostream>
 
 class GUIMonitor : public JadeMonitor
 {

--- a/software/gui/include/GUIMonitor.hh
+++ b/software/gui/include/GUIMonitor.hh
@@ -20,7 +20,7 @@ class GUIMonitor : public JadeMonitor
     QVector<QCPGraphData> GetPedestal(int col, int row);
     QVector<QCPGraphData> GetNoise(int col, int row);
     void Reset();
-    std::unordered_map<double, size_t> GetHistogram(const std::vector<double>& xVec);
+    std::map<double, size_t> GetHistogram(const std::vector<double>& xVec);
 
   private:
     JadeOption m_opt;
@@ -52,8 +52,8 @@ class GUIMonitor : public JadeMonitor
       std::vector<int16_t> cds_frame_adc;
       std::vector<double> mean_frame_adc;
       std::vector<double> rms_frame_adc;
-      std::unordered_map<double, size_t> hist_mean;
-      std::unordered_map<double, size_t> hist_rms;
+      std::map<double, size_t> hist_mean;
+      std::map<double, size_t> hist_rms;
     };
     std::shared_ptr<adcFrame> m_adcFrame; 
     std::shared_ptr<adcFrame> m_u_adcFrame; 

--- a/software/gui/src/GUIMonitor.cxx
+++ b/software/gui/src/GUIMonitor.cxx
@@ -96,13 +96,11 @@ QVector<QCPGraphData> GUIMonitor::GetPedestal(int col, int row){
   auto u_adcFrame = m_adcFrame; 
   lk_in.unlock();
  
-  std::unordered_map<double, size_t>::iterator meanItr;
-  
   QCPGraphData point;
 
-  for(meanItr = (u_adcFrame->hist_mean).begin(); meanItr != (u_adcFrame->hist_mean).end(); meanItr++){
-    point.key = meanItr->first; 
-    point.value = meanItr->second;
+  for(auto meanItr : u_adcFrame->hist_mean){
+    point.key = meanItr.first; 
+    point.value = meanItr.second;
     m_pedestal.append(point);
   }
 
@@ -117,13 +115,11 @@ QVector<QCPGraphData> GUIMonitor::GetNoise(int col, int row){
   auto u_adcFrame = m_adcFrame; 
   lk_in.unlock();
   
-  std::unordered_map<double, size_t>::iterator rmsItr;
-  
   QCPGraphData point;
 
-  for(rmsItr = (u_adcFrame->hist_rms).begin(); rmsItr != (u_adcFrame->hist_rms).end(); rmsItr++){
-    point.key = rmsItr->first; 
-    point.value = rmsItr->second;
+  for(auto rmsItr : u_adcFrame->hist_rms){
+    point.key = rmsItr.first; 
+    point.value = rmsItr.second;
     m_noise.append(point);
   }
 
@@ -136,9 +132,9 @@ void GUIMonitor::Reset(){
 }
 
 
-std::unordered_map<double, size_t> GUIMonitor::GetHistogram(const std::vector<double>& xVec) {
+std::map<double, size_t> GUIMonitor::GetHistogram(const std::vector<double>& xVec) {
   
-  std::unordered_map<double, size_t> hMap;                        // histogram
+  std::map<double, size_t> hMap;                        // histogram
   
   size_t bmax=0;
   

--- a/software/gui/src/GUIMonitor.cxx
+++ b/software/gui/src/GUIMonitor.cxx
@@ -1,5 +1,4 @@
 #include "GUIMonitor.hh"
-#include <iostream>
 
 
 using namespace std::chrono_literals;

--- a/software/gui/src/GUIMonitor.cxx
+++ b/software/gui/src/GUIMonitor.cxx
@@ -28,8 +28,8 @@ GUIMonitor::GUIMonitor(const JadeOption& options):
   m_u_adcFrame->mean_frame_adc.resize(m_nx*m_ny,0);
   m_u_adcFrame->rms_frame_adc.resize(m_nx*m_ny,0);
   
-  m_u_adcFrame->hist_mean = std::make_shared<TH1D>(Form("mean_%s",m_curr_time),"mean",4000,-2000,2000);
-  m_u_adcFrame->hist_rms = std::make_shared<TH1D>(Form("rms_%s",m_curr_time),"rms",4000,-2000,2000);
+  m_u_adcFrame->hist_mean = {{0,0}};
+  m_u_adcFrame->hist_rms = {{0,0}};
  
   m_adcFrame = m_u_adcFrame; 
 }
@@ -54,9 +54,12 @@ void GUIMonitor::Monitor(JadeDataFrameSP df)
   std::transform(m_sum_frame_adc.begin(), m_sum_frame_adc.end(), m_u_adcFrame->mean_frame_adc.begin(), std::bind2nd(std::divides<int16_t>(),m_ev_num)); 
 
   std::transform(m_mean_frame_adc.begin(), m_mean_frame_adc.end(), m_u_adcFrame->cds_frame_adc.begin(), m_u_adcFrame->rms_frame_adc.begin(), std::minus<int16_t>()); 
- 
-  m_u_adcFrame->hist_mean->Fill(m_u_adcFrame->mean_frame_adc.at(m_row+m_col*m_ny));
-  m_u_adcFrame->hist_rms->Fill(m_u_adcFrame->rms_frame_adc.at(m_row+m_col*m_ny));
+
+  m_mean.push_back(m_u_adcFrame->mean_frame_adc.at(m_row+m_col*m_ny));
+  m_rms.push_back(m_u_adcFrame->rms_frame_adc.at(m_row+m_col*m_ny));
+  
+  m_u_adcFrame->hist_mean = GetHistogram(m_mean);
+  m_u_adcFrame->hist_rms = GetHistogram(m_rms);
 
   std::unique_lock<std::mutex> lk_out(m_mx_get);
   m_adcFrame = m_u_adcFrame; 
@@ -92,14 +95,17 @@ QVector<QCPGraphData> GUIMonitor::GetPedestal(int col, int row){
   std::unique_lock<std::mutex> lk_in(m_mx_get);
   auto u_adcFrame = m_adcFrame; 
   lk_in.unlock();
+ 
+  std::unordered_map<double, size_t>::iterator meanItr;
   
   QCPGraphData point;
 
-  for(int iBin=0; iBin<u_adcFrame->hist_mean->GetNbinsX(); iBin++){
-    point.key = u_adcFrame->hist_mean->GetXaxis()->GetBinCenter(iBin); 
-    point.value = u_adcFrame->hist_mean->GetBinContent(iBin);
+  for(meanItr = (u_adcFrame->hist_mean).begin(); meanItr != (u_adcFrame->hist_mean).end(); meanItr++){
+    point.key = meanItr->first; 
+    point.value = meanItr->second;
     m_pedestal.append(point);
   }
+
   return m_pedestal;
 }
 
@@ -111,11 +117,13 @@ QVector<QCPGraphData> GUIMonitor::GetNoise(int col, int row){
   auto u_adcFrame = m_adcFrame; 
   lk_in.unlock();
   
+  std::unordered_map<double, size_t>::iterator rmsItr;
+  
   QCPGraphData point;
 
-  for(int iBin=0; iBin<u_adcFrame->hist_rms->GetNbinsX(); iBin++){
-    point.key = u_adcFrame->hist_rms->GetXaxis()->GetBinCenter(iBin); 
-    point.value = u_adcFrame->hist_rms->GetBinContent(iBin);
+  for(rmsItr = (u_adcFrame->hist_rms).begin(); rmsItr != (u_adcFrame->hist_rms).end(); rmsItr++){
+    point.key = rmsItr->first; 
+    point.value = rmsItr->second;
     m_noise.append(point);
   }
 
@@ -123,6 +131,23 @@ QVector<QCPGraphData> GUIMonitor::GetNoise(int col, int row){
 }
 
 void GUIMonitor::Reset(){
-  m_u_adcFrame->hist_mean->Reset();
-  m_u_adcFrame->hist_rms->Reset();
+  m_u_adcFrame->hist_mean.clear();
+  m_u_adcFrame->hist_rms.clear();
+}
+
+
+std::unordered_map<double, size_t> GUIMonitor::GetHistogram(const std::vector<double>& xVec) {
+  
+  std::unordered_map<double, size_t> hMap;                        // histogram
+  
+  size_t bmax=0;
+  
+  std::for_each(xVec.begin(), xVec.end(), 
+      [&hMap, &bmax](const double &element)
+      {
+        hMap[element]++;
+        bmax=std::max(bmax, hMap[element]);
+      });
+
+  return hMap;
 }


### PR DESCRIPTION
Only ROOT5 can be used in Windows. Unfortunately, it is not correspond with C++11. I have to make a hard decision to remove root. The data type in root makes something easily, for example, TH1D. I use map and a litter STL algorithm to take a part place of ROOT histogram.